### PR TITLE
Add production compose file, make prod backend run on gunicorn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,14 @@ build-dev:
 dev:
 	docker-compose up
 
+build-prod:
+	docker-compose -f docker-compose.yml -f docker-compose.prod.yml build
+
+prod:
+	docker-compose -f docker-compose.yml -f docker-compose.prod.yml up
+
+test-backend:
+	docker-compose exec backend pytest
+
 shell:
-	docker-commpose exec backend python manage.py shell
+	docker-compose exec backend python manage.py shell

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,6 +14,8 @@ WORKDIR /app
 COPY ./poetry.lock ./pyproject.toml /app/
 
 RUN poetry config virtualenvs.create false
-RUN poetry install
+RUN poetry install \
+    $(if [ "$DJANGO_ENV" = 'production' ]; then echo '--no-dev'; fi) \
+    --no-interaction --no-ansi
 
 COPY . /app

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -492,6 +492,23 @@ python-dateutil = ">=2.7"
 
 [[package]]
 category = "main"
+description = "WSGI HTTP Server for UNIX"
+name = "gunicorn"
+optional = false
+python-versions = ">=3.4"
+version = "20.0.4"
+
+[package.dependencies]
+setuptools = ">=3.0"
+
+[package.extras]
+eventlet = ["eventlet (>=0.9.7)"]
+gevent = ["gevent (>=0.13)"]
+setproctitle = ["setproctitle"]
+tornado = ["tornado (>=0.2)"]
+
+[[package]]
+category = "main"
 description = "Python wrapper for hiredis"
 name = "hiredis"
 optional = false
@@ -892,6 +909,14 @@ six = ">=1.5"
 
 [[package]]
 category = "main"
+description = "Strict separation of settings from code."
+name = "python-decouple"
+optional = false
+python-versions = "*"
+version = "3.4"
+
+[[package]]
+category = "main"
 description = "World timezone definitions, modern and historical"
 name = "pytz"
 optional = false
@@ -1127,7 +1152,7 @@ test = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 
 [metadata]
-content-hash = "b3180ba1574127a156ad1485d39d80a14ad6324d3fc3fb7b4e1788a5fc8b8ae7"
+content-hash = "0dac8541335291caf1a05fdf1c07fdad9d5d5f9fad5f20e6b3ffb756b77ff93f"
 python-versions = "^3.8"
 
 [metadata.files]
@@ -1318,6 +1343,10 @@ faker = [
 freezegun = [
     {file = "freezegun-1.1.0-py2.py3-none-any.whl", hash = "sha256:2ae695f7eb96c62529f03a038461afe3c692db3465e215355e1bb4b0ab408712"},
     {file = "freezegun-1.1.0.tar.gz", hash = "sha256:177f9dd59861d871e27a484c3332f35a6e3f5d14626f2bf91be37891f18927f3"},
+]
+gunicorn = [
+    {file = "gunicorn-20.0.4-py2.py3-none-any.whl", hash = "sha256:cd4a810dd51bf497552cf3f863b575dabd73d6ad6a91075b65936b151cbf4f9c"},
+    {file = "gunicorn-20.0.4.tar.gz", hash = "sha256:1904bb2b8a43658807108d59c3f3d56c2b6121a701161de0ddf9ad140073c626"},
 ]
 hiredis = [
     {file = "hiredis-1.1.0-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:289b31885b4996ce04cadfd5fc03d034dce8e2a8234479f7c9e23b9e245db06b"},
@@ -1618,6 +1647,10 @@ pytest-django = [
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
     {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
+]
+python-decouple = [
+    {file = "python-decouple-3.4.tar.gz", hash = "sha256:2e5adb0263a4f963b58d7407c4760a2465d464ee212d733e2a2c179e54c08d8f"},
+    {file = "python_decouple-3.4-py3-none-any.whl", hash = "sha256:a8268466e6389a639a20deab9d880faee186eb1eb6a05e54375bdf158d691981"},
 ]
 pytz = [
     {file = "pytz-2020.5-py2.py3-none-any.whl", hash = "sha256:16962c5fb8db4a8f63a26646d8886e9d769b6c511543557bc84e9569fb9a9cb4"},

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,6 +18,8 @@ djangorestframework-camel-case = "^1.2.0"
 celery = "^5.0.5"
 redis = "^3.5.3"
 drf-yasg = "^1.20.0"
+gunicorn = "^20.0.4"
+python-decouple = "^3.4"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.2"

--- a/backend/src/settings.py
+++ b/backend/src/settings.py
@@ -1,15 +1,16 @@
 import os
 
+from decouple import config
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
-SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
+SECRET_KEY = config("DJANGO_SECRET_KEY")
 
-DEBUG = os.environ.get("DJANGO_DEBUG")
+DEBUG = config("DJANGO_DEBUG", default=False, cast=bool)
 
-ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS").split(",")
+ALLOWED_HOSTS = config("ALLOWED_HOSTS").split(",")
 
-APP_URL = os.environ.get("APP_URL")
+APP_URL = config("APP_URL")
 
 INSTALLED_APPS = [
     # django apps
@@ -61,8 +62,8 @@ WSGI_APPLICATION = "src.wsgi.application"
 
 ASGI_APPLICATION = "src.routing.application"
 
-REDIS_HOST = os.environ.get("REDIS_HOST")
-REDIS_PORT = os.environ.get("REDIS_PORT")
+REDIS_HOST = config("REDIS_HOST")
+REDIS_PORT = config("REDIS_PORT", cast=int)
 
 CHANNEL_LAYERS = {
     "default": {
@@ -74,11 +75,11 @@ CHANNEL_LAYERS = {
 
 # Database
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases
-DB_HOST = os.environ.get("POSTGRES_HOST")
-DB_PORT = os.environ.get("POSTGRES_PORT")
-DB_NAME = os.environ.get("POSTGRES_DB")
-DB_USER = os.environ.get("POSTGRES_USER")
-DB_PASSWORD = os.environ.get("POSTGRES_PASSWORD")
+DB_HOST = config("POSTGRES_HOST")
+DB_PORT = config("POSTGRES_PORT", cast=int)
+DB_NAME = config("POSTGRES_DB")
+DB_USER = config("POSTGRES_USER")
+DB_PASSWORD = config("POSTGRES_PASSWORD")
 
 DATABASES = {
     "default": {
@@ -141,17 +142,17 @@ USE_TZ = True
 
 STATIC_URL = "/static/"
 
-STATICFILES_DIRS = (os.path.join(BASE_DIR, "/static"),)
+STATIC_ROOT = os.path.join(BASE_DIR, "static")
 
 MEDIA_ROOT = "/static/"
 
 
 # Email settings
 
-EMAIL_HOST = os.environ.get("EMAIL_HOST")
-EMAIL_PORT = os.environ.get("EMAIL_PORT")
-EMAIL_HOST_USER = os.environ.get("EMAIL_USER")
-EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_PASSWORD")
+EMAIL_HOST = config("EMAIL_HOST")
+EMAIL_PORT = config("EMAIL_PORT", cast=int)
+EMAIL_HOST_USER = config("EMAIL_USER")
+EMAIL_HOST_PASSWORD = config("EMAIL_PASSWORD")
 EMAIL_USE_TLS = True
 
 # Celery settings

--- a/backend/src/wsgi.py
+++ b/backend/src/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "Chatroom.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "src.settings")
 
 application = get_wsgi_application()

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,22 @@
+version: "3.8"
+services:
+  backend:
+    build:
+      args:
+        - DJANGO_ENV="production"
+    env_file:
+      - .env.prod
+    command: bash -c "chmod +x scripts/wait_for_db.sh
+      && scripts/wait_for_db.sh
+      && python manage.py makemigrations
+      && python manage.py migrate --noinput
+      && python manage.py collectstatic --noinput
+      && gunicorn src.wsgi:application --bind 0.0.0.0:8000"
+
+  db:
+    env_file:
+      - .env.prod
+
+  celery-normal-priority:
+    env_file:
+      - .env.prod


### PR DESCRIPTION
* Added docker-compose configuration for production build.
* Added `python-decouple` for better env management.
* Dev dependencies are now not installed by poetry in production build
